### PR TITLE
Resolves "TypeError: not all arguments converted during string formattin...

### DIFF
--- a/addons/stock/migrations/8.0.1.1/post-migration.py
+++ b/addons/stock/migrations/8.0.1.1/post-migration.py
@@ -558,7 +558,7 @@ def migrate_product_supply_method(cr, registry):
     if mto_route_id:
         product_ids = []
         cr.execute("SELECT id FROM product_template WHERE %s = '%s'" % (
-            procure_method_legacy, 'make_to_order')
+            procure_method_legacy, 'make_to_order'))
         for res in cr.fetchall():
             product_ids.append(res[0])
 

--- a/addons/stock/migrations/8.0.1.1/post-migration.py
+++ b/addons/stock/migrations/8.0.1.1/post-migration.py
@@ -557,8 +557,8 @@ def migrate_product_supply_method(cr, registry):
 
     if mto_route_id:
         product_ids = []
-        cr.execute("SELECT id FROM product_template WHERE %s = '%s'" % (
-            procure_method_legacy, 'make_to_order'))
+        cr.execute("SELECT id FROM product_template WHERE %s = %%s" % (
+            procure_method_legacy,), ('make_to_order',))
         for res in cr.fetchall():
             product_ids.append(res[0])
 

--- a/addons/stock/migrations/8.0.1.1/post-migration.py
+++ b/addons/stock/migrations/8.0.1.1/post-migration.py
@@ -557,8 +557,8 @@ def migrate_product_supply_method(cr, registry):
 
     if mto_route_id:
         product_ids = []
-        cr.execute("SELECT id FROM product_template WHERE %s = %%s" % (
-            procure_method_legacy, ('make_to_order',)))
+        cr.execute("SELECT id FROM product_template WHERE %s = '%s'" % (
+            procure_method_legacy, 'make_to_order')
         for res in cr.fetchall():
             product_ids.append(res[0])
 


### PR DESCRIPTION
Resolves "TypeError: not all arguments converted during string formatting" on line 561 of post_migration.py

This is the only critical error that I got while running this part of the migration, so you could consider this a successful review of whether the 'stock' migration actually runs. I also checked whether my changed query is correctly formatted and outputs results. But I didn't review the migrated 'stock' data yet.
